### PR TITLE
Promote development → test (6 commits)

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -27,13 +27,9 @@ Any code change should include review of:
 - **Configuration** - update env vars or config files if affected
 - **Dependencies** - check for unused deps after removing code
 
-Run before committing:
-
-```bash
-bun run lint
-bun run typecheck
-bun test
-```
+Run before committing: see
+[.github/instructions/checks.instructions.md](.github/instructions/checks.instructions.md) (synced
+from dx) for the exact commands this repo's CI enforces.
 
 ## Imports
 

--- a/.github/instructions/checks.instructions.md
+++ b/.github/instructions/checks.instructions.md
@@ -1,0 +1,27 @@
+---
+applyTo: "**"
+description:
+  "Exact pre-commit commands for the bun-lib-mqtt CI archetype, kept in sync with ci.yaml"
+---
+
+# Pre-commit Checks
+
+This repo's `ci.yaml` is generated from `dx/ci-templates/bun-lib-mqtt.yaml`. Run these before
+committing so CI passes on the first try:
+
+```bash
+bun run lint
+bun run format
+bun run typecheck
+bun run test:unit
+bun run test:conformance   # requires `mosquitto-clients` installed locally
+```
+
+On PRs targeting `main`, CI additionally runs and blocks on:
+
+```bash
+bun run build && bun run validate:runtime      # cross-runtime export shape
+npx vitest run src/__tests__/unit              # Node.js
+deno run -A npm:vitest run src/__tests__/unit  # Deno
+bun run test:coverage:unit                     # line coverage must be >=80%
+```

--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -50,8 +50,19 @@ only the map to them.
   Omitted sections render `- none`. When a decision crystallizes, post it with
   `dx decision add --title … --body-file …` (or `--status/--context/--decision/--consequences …`) —
   the command owns the canonical form, and `dx decision lint` flags any that drift from it.
-- **Link, don't duplicate.** The agent-only memory log is a scratch mirror, not the system of record
-  — promote durable facts to the board (state) or Discussions (why).
+- **End each planning/discovery session (no code changed) the same way.** A conversation that only
+  produces ideas is not done until every idea worth keeping has a durable home. Before closing out:
+  audit each design thread discussed, including tangential or explicitly-deferred ones, and confirm
+  it landed as either a Decision (the "why", even for work with no issue yet) or a Backlog issue
+  (the "what", even if unstartable today) — not as a mention buried in another issue's `Links`
+  section and not as prose in a chat reply. "We'll scope this properly next time" is fine as a
+  decision; leaving the idea undocumented until "next time" is not — post a placeholder Decision or
+  issue capturing the shape of it now, thin as it may be.
+- **Link, don't duplicate — and memory is not a substitute for either.** The agent-only memory log
+  (session or repo-scoped) is a scratch mirror for continuity within a tool's own context, not the
+  system of record: it is invisible to a different session, a different agent, or a human teammate.
+  If a fact would matter to whoever picks this up next, it belongs on the board or in Discussions,
+  full stop — memory may additionally note it for convenience, but never _only_ note it there.
 
 ## Branching model
 

--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -41,6 +41,17 @@ only the map to them.
   without claiming it. If the work embodies a design choice rather than an obvious continuation,
   post it with `dx decision add` **before** implementing — the rationale should precede the code,
   not document it after the fact.
+- **When to create a new Initiative vs. reuse one vs. just file a flat issue.** Default to *not*
+  creating one — a single well-scoped issue never needs its own Initiative, and a small addition to
+  existing work belongs under whichever Initiative it naturally extends. Spin up a new Initiative
+  once a body of work has actually earned independent tracking: roughly three or more
+  concretely-scoped issues (not placeholders) sharing a dependency chain or narrative distinct from
+  any existing Initiative, expected to span multiple sessions. A single placeholder issue capturing
+  a deferred idea does not need its own Initiative yet — leave it inside the most related existing
+  one and only split it out once the idea grows enough real, scoped issues to justify it. (This is
+  how a body of billing/email planning grew Automations and Dashboards into their own Initiatives
+  mid-session once they had real scope, while an automations-billing-metering thread stayed a single
+  placeholder inside Billing & Usage until it did.)
 - **Before changing settled design** → search 🧭 Decisions for the relevant decision; it records the
   alternatives already rejected, so you don't relitigate them.
 - **End each session** → update the issue: set `Status` and post a Snapshot comment. Always post it

--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -41,7 +41,7 @@ only the map to them.
   without claiming it. If the work embodies a design choice rather than an obvious continuation,
   post it with `dx decision add` **before** implementing — the rationale should precede the code,
   not document it after the fact.
-- **When to create a new Initiative vs. reuse one vs. just file a flat issue.** Default to *not*
+- **When to create a new Initiative vs. reuse one vs. just file a flat issue.** Default to _not_
   creating one — a single well-scoped issue never needs its own Initiative, and a small addition to
   existing work belongs under whichever Initiative it naturally extends. Spin up a new Initiative
   once a body of work has actually earned independent tracking: roughly three or more

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -157,7 +157,7 @@ jobs:
           import re
           import subprocess
           import sys
-          
+
           PROMOTION_TITLE = re.compile(r"^(Promote .* → .* \(\d+ commits?\)|Merge .* into (main|test|development))")
           LEAF_EXCLUDE = [
               re.compile(r"^docs:"),
@@ -167,8 +167,8 @@ jobs:
               re.compile(r"Merge pull request"),
               re.compile(r"Merge branch"),
           ]
-          
-          
+
+
           def gh_api_json(path, method="GET", fields=None):
               cmd = ["gh", "api", path]
               if method != "GET":
@@ -179,14 +179,14 @@ jobs:
               if out.returncode != 0:
                   return None, out.stderr
               return json.loads(out.stdout), None
-          
-          
+
+
           class Resolver:
               def __init__(self, repo, repo_dir):
                   self.repo = repo
                   self.repo_dir = repo_dir
                   self.cache = {}
-          
+
               def pr_for_commit(self, sha):
                   key = f"commit_pr:{sha}"
                   if key in self.cache:
@@ -205,7 +205,7 @@ jobs:
                           }
                   self.cache[key] = result
                   return result
-          
+
               def pr_commits(self, number):
                   key = f"pr_commits:{number}"
                   if key in self.cache:
@@ -214,7 +214,7 @@ jobs:
                   result = [c["sha"] for c in (commits or [])]
                   self.cache[key] = result
                   return result
-          
+
               def commit_info(self, sha):
                   key = f"commit_info:{sha}"
                   if key in self.cache:
@@ -232,7 +232,7 @@ jobs:
                   }
                   self.cache[key] = result
                   return result
-          
+
               def resolve_leaves(self, sha, seen, depth=0):
                   if sha in seen or depth > 12:
                       return []
@@ -244,12 +244,12 @@ jobs:
                           leaves.extend(self.resolve_leaves(inner_sha, seen, depth + 1))
                       return leaves
                   return [pr if pr else self.commit_info(sha)]
-          
-          
+
+
           def excluded(title):
               return any(p.search(title) for p in LEAF_EXCLUDE)
-          
-          
+
+
           def format_bullet(leaf):
               title, author, url = leaf["title"], leaf.get("author"), leaf.get("url")
               if author and url:
@@ -257,8 +257,8 @@ jobs:
               if url:
                   return f"- {title} in {url}"
               return f"- {title}"
-          
-          
+
+
           def build_bullets(repo, repo_dir, prev, tag):
               resolver = Resolver(repo, repo_dir)
               rng = f"{prev}..{tag}" if prev else tag
@@ -267,12 +267,12 @@ jobs:
                   capture_output=True, text=True, check=True,
               ).stdout
               shas = [s for s in log.split("\n") if s.strip()]
-          
+
               seen = set()
               all_leaves = []
               for sha in shas:
                   all_leaves.extend(resolver.resolve_leaves(sha, seen))
-          
+
               bullets, seen_titles = [], set()
               for leaf in reversed(all_leaves):  # newest first
                   if excluded(leaf["title"]) or leaf["title"] in seen_titles:
@@ -280,8 +280,8 @@ jobs:
                   seen_titles.add(leaf["title"])
                   bullets.append(format_bullet(leaf))
               return bullets
-          
-          
+
+
           def main():
               ap = argparse.ArgumentParser()
               ap.add_argument("--repo", required=True, help="owner/name")
@@ -289,7 +289,7 @@ jobs:
               ap.add_argument("--prev-tag", default=None)
               ap.add_argument("--repo-dir", default=".")
               args = ap.parse_args()
-          
+
               bullets = build_bullets(args.repo, args.repo_dir, args.prev_tag, args.tag)
               parts = ["## What's Changed", ""]
               parts.extend(bullets)
@@ -299,8 +299,8 @@ jobs:
               if args.prev_tag:
                   parts.append(f"**Full Changelog**: https://github.com/{args.repo}/compare/{args.prev_tag}...{args.tag}")
               print("\n".join(parts))
-          
-          
+
+
           if __name__ == "__main__":
               main()
           PYEOF

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -106,6 +106,11 @@ jobs:
       contents: write
     if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
       - name: Create release if missing
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -119,7 +124,194 @@ jobs:
             exit 0
           fi
 
+          # PREV_TAG is the most recent tag reachable before this one, if any.
+          PREV_TAG=$(git tag --sort=-creatordate --merged "$TAG" | grep -Fxv "$TAG" | head -1 || true)
+
+          # Injected from dx scripts/changelog-notes by release-sync — do not
+          # hand-edit; change the source script and re-run release-sync.
+          # Recursively unpacks squashed promotion-hop commits back to their
+          # real leaf commits, since neither `gh release create
+          # --generate-notes` nor GoReleaser's `changelog.use: github` can see
+          # past the single squash-commit each development -> test -> main
+          # hop produces.
+          cat > /tmp/changelog-notes.py <<'PYEOF'
+          # changelog-notes — build real release notes for a tag by recursively unpacking
+          # squashed promotion-hop commits back to their leaf feat/fix/etc. commits.
+          #
+          # Neither `gh release create --generate-notes` nor GoReleaser's `changelog.use:
+          # github` can do this: both only ever see one squash-commit per development ->
+          # test -> main promotion hop, never the real commits that were squashed away.
+          # This script walks the commit range for a tag, and for each commit whose title
+          # matches the promotion-hop shape, looks up that PR's pre-squash commit list via
+          # the GitHub API and recurses into it, until it reaches real leaf commits.
+          #
+          # Usage:
+          #   changelog-notes --repo owner/name --tag TAG [--prev-tag PREV] [--repo-dir DIR]
+          #
+          # Requires: gh (authenticated), git (run inside, or --repo-dir pointing at, a
+          # checkout with full history/tags — i.e. actions/checkout with fetch-depth: 0).
+          #
+          # Prints the release body (## What's Changed / ## Full Changelog) to stdout.
+          import argparse
+          import json
+          import re
+          import subprocess
+          import sys
+          
+          PROMOTION_TITLE = re.compile(r"^(Promote .* → .* \(\d+ commits?\)|Merge .* into (main|test|development))")
+          LEAF_EXCLUDE = [
+              re.compile(r"^docs:"),
+              re.compile(r"^test:"),
+              re.compile(r"^chore:"),
+              re.compile(r"^ci:"),
+              re.compile(r"Merge pull request"),
+              re.compile(r"Merge branch"),
+          ]
+          
+          
+          def gh_api_json(path, method="GET", fields=None):
+              cmd = ["gh", "api", path]
+              if method != "GET":
+                  cmd += ["-X", method]
+              for k, v in (fields or {}).items():
+                  cmd += ["-f", f"{k}={v}"]
+              out = subprocess.run(cmd, capture_output=True, text=True)
+              if out.returncode != 0:
+                  return None, out.stderr
+              return json.loads(out.stdout), None
+          
+          
+          class Resolver:
+              def __init__(self, repo, repo_dir):
+                  self.repo = repo
+                  self.repo_dir = repo_dir
+                  self.cache = {}
+          
+              def pr_for_commit(self, sha):
+                  key = f"commit_pr:{sha}"
+                  if key in self.cache:
+                      return self.cache[key]
+                  prs, _ = gh_api_json(f"repos/{self.repo}/commits/{sha}/pulls")
+                  result = None
+                  if prs:
+                      merged = [p for p in prs if p.get("merged_at")]
+                      if merged:
+                          p = merged[0]
+                          result = {
+                              "number": p["number"],
+                              "title": p["title"],
+                              "author": (p.get("user") or {}).get("login"),
+                              "url": p.get("html_url"),
+                          }
+                  self.cache[key] = result
+                  return result
+          
+              def pr_commits(self, number):
+                  key = f"pr_commits:{number}"
+                  if key in self.cache:
+                      return self.cache[key]
+                  commits, _ = gh_api_json(f"repos/{self.repo}/pulls/{number}/commits")
+                  result = [c["sha"] for c in (commits or [])]
+                  self.cache[key] = result
+                  return result
+          
+              def commit_info(self, sha):
+                  key = f"commit_info:{sha}"
+                  if key in self.cache:
+                      return self.cache[key]
+                  data, _ = gh_api_json(f"repos/{self.repo}/commits/{sha}")
+                  author = (data or {}).get("author") or {}
+                  msg = subprocess.run(
+                      ["git", "-C", self.repo_dir, "log", "-1", "--pretty=format:%s", sha],
+                      capture_output=True, text=True, check=True,
+                  ).stdout.strip()
+                  result = {
+                      "title": msg,
+                      "author": author.get("login"),
+                      "url": f"https://github.com/{self.repo}/commit/{sha}",
+                  }
+                  self.cache[key] = result
+                  return result
+          
+              def resolve_leaves(self, sha, seen, depth=0):
+                  if sha in seen or depth > 12:
+                      return []
+                  seen.add(sha)
+                  pr = self.pr_for_commit(sha)
+                  if pr and PROMOTION_TITLE.match(pr["title"]):
+                      leaves = []
+                      for inner_sha in self.pr_commits(pr["number"]):
+                          leaves.extend(self.resolve_leaves(inner_sha, seen, depth + 1))
+                      return leaves
+                  return [pr if pr else self.commit_info(sha)]
+          
+          
+          def excluded(title):
+              return any(p.search(title) for p in LEAF_EXCLUDE)
+          
+          
+          def format_bullet(leaf):
+              title, author, url = leaf["title"], leaf.get("author"), leaf.get("url")
+              if author and url:
+                  return f"- {title} by @{author} in {url}"
+              if url:
+                  return f"- {title} in {url}"
+              return f"- {title}"
+          
+          
+          def build_bullets(repo, repo_dir, prev, tag):
+              resolver = Resolver(repo, repo_dir)
+              rng = f"{prev}..{tag}" if prev else tag
+              log = subprocess.run(
+                  ["git", "-C", repo_dir, "log", rng, "--pretty=format:%H", "--reverse"],
+                  capture_output=True, text=True, check=True,
+              ).stdout
+              shas = [s for s in log.split("\n") if s.strip()]
+          
+              seen = set()
+              all_leaves = []
+              for sha in shas:
+                  all_leaves.extend(resolver.resolve_leaves(sha, seen))
+          
+              bullets, seen_titles = [], set()
+              for leaf in reversed(all_leaves):  # newest first
+                  if excluded(leaf["title"]) or leaf["title"] in seen_titles:
+                      continue
+                  seen_titles.add(leaf["title"])
+                  bullets.append(format_bullet(leaf))
+              return bullets
+          
+          
+          def main():
+              ap = argparse.ArgumentParser()
+              ap.add_argument("--repo", required=True, help="owner/name")
+              ap.add_argument("--tag", required=True)
+              ap.add_argument("--prev-tag", default=None)
+              ap.add_argument("--repo-dir", default=".")
+              args = ap.parse_args()
+          
+              bullets = build_bullets(args.repo, args.repo_dir, args.prev_tag, args.tag)
+              parts = ["## What's Changed", ""]
+              parts.extend(bullets)
+              parts.append("")
+              parts.append("## Full Changelog")
+              parts.append("")
+              if args.prev_tag:
+                  parts.append(f"**Full Changelog**: https://github.com/{args.repo}/compare/{args.prev_tag}...{args.tag}")
+              print("\n".join(parts))
+          
+          
+          if __name__ == "__main__":
+              main()
+          PYEOF
+
+          if [[ -n "$PREV_TAG" ]]; then
+            python3 /tmp/changelog-notes.py --repo "$GH_REPO" --tag "$TAG" --prev-tag "$PREV_TAG" > /tmp/notes.md
+          else
+            python3 /tmp/changelog-notes.py --repo "$GH_REPO" --tag "$TAG" > /tmp/notes.md
+          fi
+
           gh release create "$TAG" \
             --verify-tag \
             --title "$TAG" \
-            --generate-notes
+            --notes-file /tmp/notes.md


### PR DESCRIPTION
Promotes `development` → `test` (6 commits).

- style(project-context): normalize emphasis markers
- docs(project-context): sync initiative-creation guidance from dx
- docs: add synced pre-commit checks instructions from dx
- style(release): strip trailing whitespace from embedded changelog-notes script
- docs(project-context): sync planning-session guidance from dx
- chore(release): recursively unpack squashed commits for real changelog content