### PR TITLE
fix(ci): vendor report-scan-failure action for public-repo compatibility

### DIFF
--- a/.github/actions/report-scan-failure/action.yaml
+++ b/.github/actions/report-scan-failure/action.yaml
@@ -1,0 +1,32 @@
+# Vendored by dx/scripts/audit-sync from dx's .github/actions/report-scan-failure/action.yaml. Do not edit directly — change the source in dx and re-run audit-sync.
+
+name: "Report or resolve scan failure"
+description: >
+  Files (or bumps) a board-ready issue when a scheduled scan step genuinely fails, or closes it once
+  the scan is green again and nobody has claimed it yet. Dedupes on the issue title, so re-runs of a
+  still-failing scan never pile up duplicate issues.
+inputs:
+  mode:
+    description: "report (scan just failed) or resolve (scan just passed)"
+    required: true
+  title:
+    description: "Stable anchor used as both the issue title and the dedup key."
+    required: true
+  github-token:
+    description: "Token with this repo's issues:write (e.g. secrets.GITHUB_TOKEN)."
+    required: true
+  run-url:
+    description: "URL of the workflow run to link from the issue (mode: report)."
+    required: false
+    default: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+runs:
+  using: "composite"
+  steps:
+    - shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github-token }}
+        REPO: ${{ github.repository }}
+        MODE: ${{ inputs.mode }}
+        TITLE: ${{ inputs.title }}
+        RUN_URL: ${{ inputs.run-url }}
+      run: ${{ github.action_path }}/run.sh

--- a/.github/actions/report-scan-failure/run.sh
+++ b/.github/actions/report-scan-failure/run.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Vendored by dx/scripts/audit-sync from dx's .github/actions/report-scan-failure/run.sh. Do not edit directly — change the source in dx and re-run audit-sync.
+# Implementation for the report-scan-failure composite action. See action.yaml for inputs.
+set -euo pipefail
+
+: "${REPO:?}" "${MODE:?}" "${TITLE:?}"
+
+existing="$(gh issue list --repo "$REPO" --state open --search "\"${TITLE}\"" \
+  --json number,title --jq "[.[] | select(.title == \"${TITLE}\")][0].number // empty")"
+
+case "$MODE" in
+report)
+  if [[ -n "$existing" ]]; then
+    gh issue comment "$existing" --repo "$REPO" --body "Still failing as of ${RUN_URL}."
+    echo "report-scan-failure: bumped existing issue #${existing}"
+  else
+    body="### Why
+The scheduled scan is failing, which means it found something real rather than a one-off flake —
+someone needs to look at the failing run and fix the underlying problem.
+
+### Scope / contract
+Investigate ${RUN_URL}, determine the root cause, and resolve it (dependency bump, code fix, or a
+documented, justified suppression). Do not silence the check without addressing the finding.
+
+### Acceptance
+- [ ] Root cause identified
+- [ ] Fix applied
+- [ ] The workflow passes again on this repo
+
+### Links
+- Failing run: ${RUN_URL}"
+    url="$(gh issue create --repo "$REPO" --title "$TITLE" --body "$body")"
+    echo "report-scan-failure: filed ${url}"
+  fi
+  ;;
+resolve)
+  if [[ -n "$existing" ]]; then
+    assignees="$(gh issue view "$existing" --repo "$REPO" --json assignees --jq '.assignees | length')"
+    if [[ "$assignees" -eq 0 ]]; then
+      gh issue comment "$existing" --repo "$REPO" \
+        --body "Resolved automatically — the workflow passed again with nobody assigned."
+      gh issue close "$existing" --repo "$REPO"
+      echo "report-scan-failure: auto-closed issue #${existing}"
+    else
+      echo "report-scan-failure: issue #${existing} is claimed; leaving it for whoever is fixing it"
+    fi
+  else
+    echo "report-scan-failure: no open issue to resolve"
+  fi
+  ;;
+*)
+  echo "report-scan-failure: unknown mode: ${MODE}" >&2
+  exit 1
+  ;;
+esac

--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -27,14 +27,14 @@ jobs:
         run: bun audit
       - name: Report failure
         if: steps.scan.outcome == 'failure'
-        uses: qualithm/dx/.github/actions/report-scan-failure@main
+        uses: ./.github/actions/report-scan-failure
         with:
           mode: report
           title: "${{ github.event.repository.name }}: bun audit found a vulnerability"
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Resolve stale failure issue
         if: steps.scan.outcome == 'success'
-        uses: qualithm/dx/.github/actions/report-scan-failure@main
+        uses: ./.github/actions/report-scan-failure
         with:
           mode: resolve
           title: "${{ github.event.repository.name }}: bun audit found a vulnerability"


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- fix(ci): vendor report-scan-failure action for public-repo compatibility

Refs qualithm/pm#498
