### PR TITLE
ci(release): sync changelog-notes leak fix from dx

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -259,25 +259,47 @@ jobs:
               return f"- {title}"
 
 
-          def build_bullets(repo, repo_dir, prev, tag):
-              resolver = Resolver(repo, repo_dir)
-              rng = f"{prev}..{tag}" if prev else tag
+          def leaf_key(leaf):
+              """Stable identity for a leaf: its PR number if known, else its title."""
+              number = leaf.get("number")
+              return f"#{number}" if number else leaf["title"]
+
+
+          def collect_leaves(resolver, repo_dir, rng):
               log = subprocess.run(
                   ["git", "-C", repo_dir, "log", rng, "--pretty=format:%H", "--reverse"],
                   capture_output=True, text=True, check=True,
               ).stdout
               shas = [s for s in log.split("\n") if s.strip()]
-
               seen = set()
-              all_leaves = []
+              leaves = []
               for sha in shas:
-                  all_leaves.extend(resolver.resolve_leaves(sha, seen))
+                  leaves.extend(resolver.resolve_leaves(sha, seen))
+              return leaves
 
-              bullets, seen_titles = [], set()
+
+          def build_bullets(repo, repo_dir, prev, tag):
+              resolver = Resolver(repo, repo_dir)
+              rng = f"{prev}..{tag}" if prev else tag
+              all_leaves = collect_leaves(resolver, repo_dir, rng)
+
+              # A promotion PR's commit list (from the GitHub API) can reach commits from
+              # before this release window — long-lived development/test branches and
+              # branch-alignment resets both cause this — so the recursion may surface
+              # PRs that already shipped in an earlier tag. The prev..tag git range only
+              # bounds the top-level promotion commits, not the recursion, and squash
+              # merges rule out SHA-ancestry filtering. Subtract everything reachable from
+              # prev so an already-released PR never reappears in a later release.
+              released = set()
+              if prev:
+                  released = {leaf_key(leaf) for leaf in collect_leaves(resolver, repo_dir, prev)}
+
+              bullets, seen_keys = [], set()
               for leaf in reversed(all_leaves):  # newest first
-                  if excluded(leaf["title"]) or leaf["title"] in seen_titles:
+                  key = leaf_key(leaf)
+                  if key in released or key in seen_keys or excluded(leaf["title"]):
                       continue
-                  seen_titles.add(leaf["title"])
+                  seen_keys.add(key)
                   bullets.append(format_bullet(leaf))
               return bullets
 


### PR DESCRIPTION
Regenerated release.yaml from dx ci-templates after qualithm/pm#491 (changelog-notes: already-released PRs leak into later releases' notes). Generated file only.