### PR TITLE
fix(deps): override linkify-it to 5.0.2 (#134)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
   "overrides": {
     "@babel/core": "7.29.6",
     "brace-expansion": "5.0.7",
+    "linkify-it": "5.0.2",
     "markdown-it": "14.2.0",
     "vite": "8.0.16",
     "ws": "8.21.0",
@@ -412,7 +413,7 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
+    "linkify-it": ["linkify-it@5.0.2", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "vite": "8.0.16",
     "ws": "8.21.0",
     "markdown-it": "14.2.0",
-    "brace-expansion": "5.0.7"
+    "brace-expansion": "5.0.7",
+    "linkify-it": "5.0.2"
   }
 }


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- fix(deps): override linkify-it to 5.0.2 (#134)

Refs qualithm/pm#325
