### PR TITLE
docs(project-context): make Status the authoritative claim marker

### DIFF
--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -14,12 +14,14 @@ Commands below are described by policy only — run `dx <cmd> --help` for flags.
 - **`README.md`** — what the repo is and how to use it; no plan or status.
 - **Engineering board** — org GitHub Projects **#3**, the plan and live state. Work items are flat,
   pickable issues grouped by `Initiative` + `Status`, with the running snapshot in each issue's
-  comments. Browse with `dx project board`; the pickup queue is `Status: Ready` with no assignee
-  (`dx project items`). Issue bodies follow the work-item form (`### Why` / `### Scope / contract` /
+  comments. Browse with `dx project board`; the pickup queue is `Status: Ready`
+  (`dx project items`). `Status` is the authoritative claim marker — claiming writes `In progress`,
+  and assignment is a human convention layered on top, since a GitHub App's `[bot]` identity can
+  never be an assignee. Issue bodies follow the work-item form (`### Why` / `### Scope / contract` /
   `### Acceptance` / `### Links`). `dx project lint` flags bodies that drift or lack an
   `Initiative`/`Size`; `dx project audit` flags state drift (`Status` vs. real issue/PR state, an
-  `In progress` item unassigned or silent >14 days, a `Ready`/`Backlog` item already assigned);
-  `dx project stats` rolls it up.
+  `In progress` item silent >14 days, a `Ready`/`Backlog` item already assigned); `dx project stats`
+  rolls it up.
 - **Size** — one agent's session effort: `XS` a one-file/one-command tweak; `S` a single file plus
   tests, one session; `M` a few files, one session; `L` multi-file or multi-session; `XL` too big —
   split it before pickup rather than claiming it. Set it when filing; `lint` requires it on every


### PR DESCRIPTION
docs(project-context): make Status the authoritative claim marker (1 commit).

- docs(project-context): make Status the authoritative claim marker