### PR TITLE
feat(report-scan-failure): refresh the issue body on repeat reports (#153)

### DIFF
--- a/.github/actions/report-scan-failure/action.yaml
+++ b/.github/actions/report-scan-failure/action.yaml
@@ -4,9 +4,10 @@ name: "Report or resolve scan failure"
 description: >
   Files (or bumps) a labelled issue when an automated check reports a problem, or closes it once the
   check is healthy again and nobody has claimed it yet. Dedupes on the issue title, so re-runs never
-  pile up duplicate issues. The default `security-audit` label (and the `off-board` label) keep
-  these off the Engineering board (Decision #66) — promote one manually with `dx project add` if it
-  turns into real, multi-session work.
+  pile up duplicate issues. When `body` is supplied it is kept in sync on every report, so a check
+  that reports findings in the body rather than pass/fail never shows stale data. The default
+  `security-audit` label (and the `off-board` label) keep these off the Engineering board (Decision
+  #66) — promote one manually with `dx project add` if it turns into real, multi-session work.
 inputs:
   mode:
     description: "report (check just failed) or resolve (check just passed)"
@@ -25,8 +26,9 @@ inputs:
     default: "security-audit"
   body:
     description:
-      "Issue body used when filing a new issue in mode=report. Defaults to a generic scan-failure
-      body."
+      "Issue body for mode=report. Also refreshes an existing issue's body when it differs, so a
+      report whose value lives in the body stays current; an unchanged body is a no-op. Omit it to
+      keep the plain bump-with-a-comment behaviour and the generic scan-failure body."
     required: false
     default: ""
   run-url:

--- a/.github/actions/report-scan-failure/run.sh
+++ b/.github/actions/report-scan-failure/run.sh
@@ -42,8 +42,21 @@ report)
   for l in $LABELS; do label_args+=(--label "$l"); done
 
   if [[ -n "$existing" ]]; then
-    gh issue comment "$existing" --repo "$REPO" --body "Still failing as of ${RUN_URL}."
-    echo "report-scan-failure: bumped existing issue #${existing}"
+    if [[ -n "${BODY:-}" ]]; then
+      # A caller that supplies a body owns the issue's contents: refresh them in place so a
+      # report whose value lives in the body (a table of findings) can't go stale, and stay
+      # silent when nothing changed so a recurring finding doesn't accrue a comment per run.
+      current="$(gh issue view "$existing" --repo "$REPO" --json body --jq .body)"
+      if [[ "$(printf '%s' "$current" | tr -d '\r')" == "$(printf '%s' "$BODY" | tr -d '\r')" ]]; then
+        echo "report-scan-failure: issue #${existing} already up to date"
+      else
+        gh issue edit "$existing" --repo "$REPO" --body "$BODY" >/dev/null
+        echo "report-scan-failure: refreshed body of issue #${existing}"
+      fi
+    else
+      gh issue comment "$existing" --repo "$REPO" --body "Still failing as of ${RUN_URL}."
+      echo "report-scan-failure: bumped existing issue #${existing}"
+    fi
   else
     body="${BODY:-}"
     if [[ -z "$body" ]]; then


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- feat(report-scan-failure): refresh the issue body on repeat reports (#153)