### PR TITLE
chore: prettier-ignore .github workflows and actions (#183)

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -2,3 +2,7 @@
 build/
 dist/
 node_modules/
+
+# Synced from dx templates; the template in dx is the formatted source.
+.github/workflows/
+.github/actions/


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- chore: prettier-ignore .github workflows and actions (#183)