### PR TITLE
docs(readme): drop publishing section (#186) (#187)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,11 +214,6 @@ bun run typecheck
 bun run bench
 ```
 
-## Publishing
-
-The package is automatically published to NPM when CI passes on main. Update the version in
-`package.json` before merging to trigger a new release.
-
 ## License
 
 Apache-2.0


### PR DESCRIPTION
Promotes `test` → `main` (1 commit).

- docs(readme): drop publishing section (#186) (#187)

Refs qualithm/pm#413
