### PR TITLE
docs(issues): add consumers/reachability section to the work-item form

### DIFF
--- a/.github/ISSUE_TEMPLATE/work.yaml
+++ b/.github/ISSUE_TEMPLATE/work.yaml
@@ -28,6 +28,19 @@ body:
     validations:
       required: true
   - type: textarea
+    id: consumers
+    attributes:
+      label: Consumers / reachability
+      description:
+        Who consumes this when it lands, and can they reach it (UI, API, SDK, MCP, CLI)? A
+        capability whose only caller is another part of the same change is a flag, not a pass —
+        agent surfaces count as consumers. If the consumer is out of scope, file the follow-up issue
+        as part of this work and link it. Past misses — a run ledger nothing exposed (platform#412),
+        a command outbox no route called (platform#406), templates argued agent-first with no agent
+        surface (platform#408).
+    validations:
+      required: true
+  - type: textarea
     id: acceptance
     attributes:
       label: Acceptance

--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -18,10 +18,10 @@ Commands below are described by policy only — run `dx <cmd> --help` for flags.
   (`dx project items`). `Status` is the authoritative claim marker — claiming writes `In progress`,
   and assignment is a human convention layered on top, since a GitHub App's `[bot]` identity can
   never be an assignee. Issue bodies follow the work-item form (`### Why` / `### Scope / contract` /
-  `### Acceptance` / `### Links`). `dx project lint` flags bodies that drift or lack an
-  `Initiative`/`Size`; `dx project audit` flags state drift (`Status` vs. real issue/PR state, an
-  `In progress` item silent >14 days, a `Ready`/`Backlog` item already assigned); `dx project stats`
-  rolls it up.
+  `### Consumers / reachability` / `### Acceptance` / `### Links`). `dx project lint` flags bodies
+  that drift or lack an `Initiative`/`Size`; `dx project audit` flags state drift (`Status` vs. real
+  issue/PR state, an `In progress` item silent >14 days, a `Ready`/`Backlog` item already assigned);
+  `dx project stats` rolls it up.
 - **Size** — one agent's session effort: `XS` a one-file/one-command tweak; `S` a single file plus
   tests, one session; `M` a few files, one session; `L` multi-file or multi-session; `XL` too big —
   split it before pickup rather than claiming it. Set it when filing; `lint` requires it on every


### PR DESCRIPTION
docs(issues): add consumers/reachability section to the work-item form (1 commit).

- docs(issues): add consumers/reachability section to the work-item form