### PR TITLE
chore(deps): refresh bun.lock against manifest (#201)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -26,11 +26,9 @@
   },
   "overrides": {
     "@babel/core": "7.29.6",
-    "brace-expansion": "5.0.9",
     "ip-address": "10.4.0",
     "linkify-it": "5.0.2",
     "markdown-it": "14.2.0",
-    "postcss": "8.5.26",
     "vite": "8.0.16",
     "ws": "8.21.0",
   },


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- chore(deps): refresh bun.lock against manifest (#201)