### PR TITLE
docs(security): point env-value conventions at env-manifest.json (#205) (#206)

### DIFF
--- a/.github/security.md
+++ b/.github/security.md
@@ -7,7 +7,9 @@ Baseline for any security-sensitive change or review in this repository.
 - **Injection** — never interpolate untrusted input into shell commands, SQL, or HTML. Parameterise
   or escape at the boundary.
 - **Secrets** — no secret in code, tests, fixtures, or example files. Secrets live in Infisical and
-  arrive as env vars; `env-example` values stay empty.
+  arrive as env vars; `env-example` values stay empty. Where a repo carries `env-manifest.json`,
+  recommended values and generation recipes live there instead — a `secret: true` var still never
+  holds a static value (env-parity blocks it).
 - **Auth** — validate input at every trust boundary, including data from the frontend (a server-side
   handler treats its caller as untrusted).
 - **Dependencies** — no new direct dependency without justification; prefer the standard


### PR DESCRIPTION
Promotes `test` → `main` (1 commit).

- docs(security): point env-value conventions at env-manifest.json (#205) (#206)