### PR TITLE
ci(coverage): run coverage on every CI run and restore push-to-main (#208)

### DIFF
--- a/.github/instructions/checks.instructions.md
+++ b/.github/instructions/checks.instructions.md
@@ -17,11 +17,16 @@ bun run test:unit
 bun run test:conformance   # requires `mosquitto-clients` installed locally
 ```
 
+CI runs coverage on every PR, whatever the target branch, and on push to `main`:
+
+```bash
+bun run test:coverage:unit                     # line coverage must be >=80%
+```
+
 On PRs targeting `main`, CI additionally runs and blocks on:
 
 ```bash
 bun run build && bun run validate:runtime      # cross-runtime export shape
 npx vitest run src/__tests__/unit              # Node.js
 deno run -A npm:vitest run src/__tests__/unit  # Deno
-bun run test:coverage:unit                     # line coverage must be >=80%
 ```

--- a/.github/instructions/project-context.instructions.md
+++ b/.github/instructions/project-context.instructions.md
@@ -75,10 +75,12 @@ Commands below are described by policy only — run `dx <cmd> --help` for flags.
   and `main` hops (a PR into `development` comes from an arbitrary feature branch, so that check
   doesn't apply there). Single-`main` repos (`ui`, `dx`, the `*-example` templates) have no chain,
   but still route issue-resolving work through a feature-branch PR into `main`, never a direct push.
-- **CI tiers** — a PR into `development` runs the cheap tier (lint, format, typecheck, unit tests);
-  the `test` and `main` hops add the expensive jobs (coverage gates, cross-runtime matrices, doc
+- **CI tiers** — a PR into `development` runs the cheap tier (lint, format, typecheck, unit tests)
+  plus coverage; the `test` and `main` hops add the expensive jobs (cross-runtime matrices, doc
   builds, packaging). Templates key this off the `is-main` output of the `changes` job, so a
-  development-targeted PR never runs an artifact-producing or packaging job.
+  development-targeted PR never runs an artifact-producing or packaging job. Coverage is
+  deliberately outside that gate — it runs on every CI run so codecov sees `development`, `test` and
+  `main` (Decision qualithm/discussions#418).
 - **Feature branches** — cut from `development` (or `main` for single-branch repos), `kebab-case`,
   PR'd back into `development` (never `test`/`main` directly) with `dx git feature`. Delete the
   branch (local and remote) as soon as its PR merges — check the PR's merge state

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,8 @@ name: CI
 on:
   pull_request:
     branches: [main, test, development]
+  push:
+    branches: [main]
   workflow_dispatch: {}
 
 concurrency:
@@ -155,7 +157,7 @@ jobs:
   coverage:
     name: Coverage
     needs: changes
-    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.is-main == 'true'
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- ci(coverage): run coverage on every CI run and restore push-to-main (#208)