### PR TITLE
chore(ci): bump Node 20 actions to Node 24-compatible pins (#225)

### DIFF
--- a/.github/workflows/audit.yaml
+++ b/.github/workflows/audit.yaml
@@ -38,7 +38,7 @@ jobs:
         run: bun audit
       - name: Create app token for pm issue filing
         id: app-token
-        uses: actions/create-github-app-token@df432ceedc7162793a195dd1713ff69aefc7379e # v2.0.6
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.PROJECTS_GH_APP_CLIENT_ID }}
           private-key: ${{ secrets.PROJECTS_GH_APP_PRIVATE_KEY }}


### PR DESCRIPTION
Promotes `development` → `test` (1 commit).

- chore(ci): bump Node 20 actions to Node 24-compatible pins (#225)